### PR TITLE
Making GPD pocket trackpoint speed tolerable

### DIFF
--- a/data/80-gpd-pocket-trackpoint.conf
+++ b/data/80-gpd-pocket-trackpoint.conf
@@ -6,4 +6,6 @@ Section "InputClass"
   Option         "MiddleEmulation" "1"
   Option         "ScrollButton"    "3"
   Option         "ScrollMethod"    "button"
+  Option         "TransformationMatrix" "2 0 0 0 2 0 0 0 1"
+  Option         "AccelSpeed" "1"
 EndSection


### PR DESCRIPTION
This trackpoint on the original GPD pocket is a little too slow. This makes it feel better.