### PR TITLE
For GPD Pocket 3, matrix is incorrect for this device

### DIFF
--- a/data/umpc-display-rotate.c
+++ b/data/umpc-display-rotate.c
@@ -34,10 +34,10 @@ static const char *orientations[] = {
 };
 
 static const char *transforms[]  = {
+  "0 -1 1 1 0 0 0 0 1",
+  "0 1 0 -1 0 1 0 0 1",
   "1 0 0 0 1 0 0 0 1",
   "-1 0 1 0 -1 1 0 0 1",
-  "0 1 0 -1 0 1 0 0 1",
-  "0 -1 1 1 0 0 0 0 1",
   NULL
 };
 


### PR DESCRIPTION
This PR fixes the matrix for GPD pocket 3. 

This script was causing the touch calibration to be thrown off on this device. I don't have access to the other devices so I was unable to test that those still function with these changes.

Happy to add some sort of conditional in if the other devices work fine.