### PR TITLE
respin: Install squashfs-tools when needed

### DIFF
--- a/umpc-ubuntu-respin.sh
+++ b/umpc-ubuntu-respin.sh
@@ -61,6 +61,12 @@ if [ ! -f /usr/bin/xorriso ]; then
   apt-get -y install xorriso
 fi
 
+if [ ! -f /usr/bin/unsquashfs ]; then
+  echo "ERROR! Unable to find /usr/bin/unsquashfs. Installing now..."
+  apt-get -y install squashfs-tools
+fi
+
+
 UMPC=""
 OPTSTRING=d:h
 while getopts ${OPTSTRING} OPT; do


### PR DESCRIPTION
Respin script fails if squashfs-tools aren't installed.

Detect and install with apt when needed.

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>