### PR TITLE
micropc: Add Sino Wealth Mouse device

### DIFF
--- a/data/80-gpd-micropc-trackpoint.conf
+++ b/data/80-gpd-micropc-trackpoint.conf
@@ -8,3 +8,14 @@ Section "InputClass"
   Option         "ScrollButton"    "2"
   Option         "ScrollMethod"    "button"
 EndSection
+
+Section "InputClass"
+  Identifier     "GPD MicroPC touchpad v2"
+  MatchProduct   "SINO WEALTH 唰匀䈀 䬀攀礀戀漀愀爀搀 Mouse"
+  MatchIsPointer "on"
+  Driver         "libinput"
+  Option         "AccelSpeed"      "1"
+  Option         "MiddleEmulation" "1"
+  Option         "ScrollButton"    "2"
+  Option         "ScrollMethod"    "button"
+EndSection


### PR DESCRIPTION
GPD MicroPC purchased August 2022 has a new type of trackpoint device, the old libinput device string doesn't match.

Add Xorg conf for the new "Sino Wealth Mouse" device.

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>